### PR TITLE
Added SAS Viya 3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ The following vendors do not allow customers to enforce IMDSv2 in their accounts
 - Databricks
 - Juniper vSRX
 - [Okta ASA agent](https://help.okta.com/asa/en-us/Content/Topics/Adv_Server_Access/docs/aws-overview.htm)
+- SAS Viya 3.5
 
 ## How accurate is this list?
 Where possible, I've linked to public support pages or Github issues for the vendors that confirm the vendor does not support IMDSv2. If that does not exist, then I have relied on multiple reports from customers (in all cases at least one such customer is someone I know personally). I have also reached out to the vendors to let them know they are on this list so they can provide corrections if this is not true. Check the commit history of this repo to see when this list was last updated.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The following vendors do not allow customers to enforce IMDSv2 in their accounts
 - Databricks
 - Juniper vSRX
 - [Okta ASA agent](https://help.okta.com/asa/en-us/Content/Topics/Adv_Server_Access/docs/aws-overview.htm)
-- SAS Viya 3.5
+- SAS Viya
 
 ## How accurate is this list?
 Where possible, I've linked to public support pages or Github issues for the vendors that confirm the vendor does not support IMDSv2. If that does not exist, then I have relied on multiple reports from customers (in all cases at least one such customer is someone I know personally). I have also reached out to the vendors to let them know they are on this list so they can provide corrections if this is not true. Check the commit history of this repo to see when this list was last updated.


### PR DESCRIPTION
Submitted after testing and confirmation from SAS support during an engagement with a financial services customer. SAS representative added IMDSv2 support has been requested by multiple customers, but is still not available.